### PR TITLE
Update for AGP 8.0.0 and Android Studio Flamingo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 ## Project
 
 * Repository: https://github.com/bsstokes/acme
-* Requirements: Android Studio Electric Eel (2022.1.1)
+* Requirements
+    * Android Studio Flamingo (2022.2.1)
+    * JDK 17 (This is the version that ships with Android Studio.)
 
 I organized my work using [issues][issues] (for high-level features) and
 [pull requests][pull_requests], which I hope helps demonstrate my thought process as I built it. Is

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 * Requirements
     * Android Studio Flamingo (2022.2.1)
     * JDK 17 (This is the version that ships with Android Studio.)
+    * For Android Studio Electric Eel, use
+      the [`pre-flamingo` tag](https://github.com/bsstokes/Acme/releases/tag/pre-flamingo).
 
 I organized my work using [issues][issues] (for high-level features) and
 [pull requests][pull_requests], which I hope helps demonstrate my thought process as I built it. Is

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,12 +25,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "17"
     }
 
     buildFeatures {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,10 +1,10 @@
-@file:Suppress("UnstableApiUsage")
+@file:Suppress("DSL_SCOPE_VIOLATION", "UnstableApiUsage")
 
 plugins {
-    id("com.android.application")
-    id("org.jetbrains.kotlin.android")
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.android)
     kotlin("kapt")
-    id("com.google.dagger.hilt.android")
+    alias(libs.plugins.hilt)
 }
 
 android {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 @file:Suppress("DSL_SCOPE_VIOLATION")
 
 plugins {
-    id("com.android.application") version libs.versions.androidGradlePlugin.get() apply false
-    id("com.android.library") version libs.versions.androidGradlePlugin.get() apply false
-    id("org.jetbrains.kotlin.android") version libs.versions.kotlin.get() apply false
-    id("com.google.dagger.hilt.android") version libs.versions.hilt.get() apply false
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.android.library) apply false
+    alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.hilt) apply false
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 @file:Suppress("DSL_SCOPE_VIOLATION")
 
 plugins {
-    id("com.android.application") version "7.4.2" apply false
-    id("com.android.library") version "7.4.2" apply false
+    id("com.android.application") version libs.versions.androidGradlePlugin.get() apply false
+    id("com.android.library") version libs.versions.androidGradlePlugin.get() apply false
     id("org.jetbrains.kotlin.android") version libs.versions.kotlin.get() apply false
     id("com.google.dagger.hilt.android") version libs.versions.hilt.get() apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-androidGradlePlugin = "7.4.2"
+androidGradlePlugin = "8.0.0"
 composeCompiler = "1.4.4"
 composeUi = "1.4.0"
 coroutines = "1.6.4"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+androidGradlePlugin = "7.4.2"
 composeCompiler = "1.4.4"
 composeUi = "1.4.0"
 coroutines = "1.6.4"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,4 +37,8 @@ turbine = { module = "app.cash.turbine:turbine", version = "0.12.1" }
 kevinsternHungarianAlgorithm = { module = "com.github.kevinstern:software-and-algorithms", version = "1.0" }
 
 [plugins]
+android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
+android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }
+hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Mar 29 08:58:30 CDT 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Update the project for AGP 8.0.0 and Android Studio Flamingo, including:

* Update to Gradle v8.0
* Update to AGP v8.0.0
* Update to JDK 17 since that's the version that's now shipping with Android Studio
* Move plugins to version catalog (TOML)